### PR TITLE
Use filter instead of map, as intended

### DIFF
--- a/src/js/array-filter.md
+++ b/src/js/array-filter.md
@@ -12,7 +12,7 @@ array.
 ```js
 const pageNumbers = [300, 150, 120, 500, 250]
 
-const shortBooks = pageNumbers.map(num => num < 200)
+const shortBooks = pageNumbers.filter(num => num < 200)
 console.log(shortBooks)
 ```
 


### PR DESCRIPTION
Very minor change, but I think this is what was intended! Using the map gives an output of `[ false, true, true, false, false ]`, and the heading here is "Using filter".